### PR TITLE
Makefile: allow building with local go toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   schedule:
   - cron:  '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION
This commit allows building the project using the local Go toolchain by
executing any make target with the `CONTAINERIZE_BUILD=false`
environment variable. This allows developers to work on the project
without Docker.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
