### PR TITLE
Makefile: enable non-docker-registries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,11 @@ jobs:
     - name: Build and push
       run: |
         make manifest
+        make clean
         REGISTRY=ghcr.io make manifest
     - name: Build and push latest
       if: github.ref == 'refs/heads/main'
       run: |
         make manifest-latest
+        make clean
         REGISTRY=ghcr.io make manifest-latest


### PR DESCRIPTION
This change enables building images and pushing manifests to multiple
registries within one single development context.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
