### PR TITLE
Change log level of no USB devices

### DIFF
--- a/deviceplugin/usb.go
+++ b/deviceplugin/usb.go
@@ -241,8 +241,7 @@ func (gp *GenericPlugin) discoverUSB() (devices []device, err error) {
 					paths = append(paths, match.BusPath())
 				}
 			} else {
-				// Should this be a Warn? It's very unusual, that's for sure...
-				level.Info(gp.logger).Log("msg", "no USB devices found attached to system")
+				level.Debug(gp.logger).Log("msg", "no USB devices found attached to system")
 			}
 		}
 		if len(paths) > 0 {


### PR DESCRIPTION
There was an original comment that stated:

```
Should this be a Warn? It's very unusual, that's for sure...
```

However, I believe it should be Debug. Any node that doesn't have USB devices attached will be flooded with logs stating that no USB devices. In many clusters, nodes don't have a USB device attached and this information is only useful if debugging in those cases. 

This issue was originally raised in https://github.com/squat/generic-device-plugin/issues/17