### PR TITLE
path: allow a device to be reused up to X times

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,20 @@ Now, the MJPEG stream could be opened by pointing a browser to [http://localhost
 
 [embedmd]:# (tmp/help.txt)
 ```txt
+Usage of bin/amd64/generic-device-plugin:
       --device stringArray        The devices to expose. This flag can be repeated to specify multiple device types.
                                   Multiple paths can be given for each type. Paths can be globs.
                                   Should be provided in the form:
                                   {"name": "<name>", "groups": [(device definitions)], "count": <count>}]}
-                                  The device definition can be either a raw path, or a USB device. You cannot define both in the same group.
-                                  For path devices, use something like: {"paths": [{"path": "<path-1>", "mountPath": "<mount-path-1>"},{"path": "<path-2>", "mountPath": "<mount-path-2>"}]}
+                                  The device definition can be either a path to a device file or a USB device. You cannot define both in the same group.
+                                  For device files, use something like: {"paths": [{"path": "<path-1>", "mountPath": "<mount-path-1>"},{"path": "<path-2>", "mountPath": "<mount-path-2>"}]}
                                   For USB devices, use something like: {"usb": [{"vendor": "1209", "product": "000F"}]}
                                   For example, to expose serial devices with different names: {"name": "serial", "groups": [{"paths": [{"path": "/dev/ttyUSB*"}]}, {"paths": [{"path": "/dev/ttyACM*"}]}]}
-                                  Paths can contain lists of devices that should be grouped and mounted into a container together as one single meta-device.
+                                  The device flag can specify lists of devices that should be grouped and mounted into a container together as one single meta-device.
                                   For example, to allocate and mount an audio capture device: {"name": "capture", "groups": [{"paths": [{"path": "/dev/snd/pcmC0D0c"}, {"path": "/dev/snd/controlC0"}]}]}
                                   For example, to expose a CH340 serial converter: {"name": "ch340", "groups": [{"usb": [{"vendor": "1a86", "product": "7523"}]}]}
-                                  A "count" can be specified to allow a discovered device to be scheduled multiple times.
+                                  A "count" can be specified to allow a discovered device group to be scheduled multiple times.
+                                  For example, to permit allocation of the FUSE device 10 times: {"name": "fuse", "groups": [{"count": 10, "paths": [{"path": "/dev/fuse"}]}]}
                                   Note: if omitted, "count" is assumed to be 1
       --domain string             The domain to use when when declaring devices. (default "squat.ai")
       --listen string             The address at which to listen for health and metrics. (default ":8080")

--- a/deviceplugin/generic.go
+++ b/deviceplugin/generic.go
@@ -48,6 +48,9 @@ func (d *DeviceSpec) Default() {
 			g.Count = 1
 		}
 		for _, p := range g.Paths {
+			if p.Limit == 0 {
+				p.Limit = 1
+			}
 			if p.Type == "" {
 				p.Type = DevicePathType
 			}

--- a/main.go
+++ b/main.go
@@ -78,14 +78,15 @@ func Main() error {
 Multiple paths can be given for each type. Paths can be globs.
 Should be provided in the form:
 {"name": "<name>", "groups": [(device definitions)], "count": <count>}]}
-The device definition can be either a raw path, or a USB device. You cannot define both in the same group.
-For path devices, use something like: {"paths": [{"path": "<path-1>", "mountPath": "<mount-path-1>"},{"path": "<path-2>", "mountPath": "<mount-path-2>"}]}
+The device definition can be either a path to a device file or a USB device. You cannot define both in the same group.
+For device files, use something like: {"paths": [{"path": "<path-1>", "mountPath": "<mount-path-1>"},{"path": "<path-2>", "mountPath": "<mount-path-2>"}]}
 For USB devices, use something like: {"usb": [{"vendor": "1209", "product": "000F"}]}
 For example, to expose serial devices with different names: {"name": "serial", "groups": [{"paths": [{"path": "/dev/ttyUSB*"}]}, {"paths": [{"path": "/dev/ttyACM*"}]}]}
-Paths can contain lists of devices that should be grouped and mounted into a container together as one single meta-device.
+The device flag can specify lists of devices that should be grouped and mounted into a container together as one single meta-device.
 For example, to allocate and mount an audio capture device: {"name": "capture", "groups": [{"paths": [{"path": "/dev/snd/pcmC0D0c"}, {"path": "/dev/snd/controlC0"}]}]}
 For example, to expose a CH340 serial converter: {"name": "ch340", "groups": [{"usb": [{"vendor": "1a86", "product": "7523"}]}]}
-A "count" can be specified to allow a discovered device to be scheduled multiple times.
+A "count" can be specified to allow a discovered device group to be scheduled multiple times.
+For example, to permit allocation of the FUSE device 10 times: {"name": "fuse", "groups": [{"count": 10, "paths": [{"path": "/dev/fuse"}]}]}
 Note: if omitted, "count" is assumed to be 1`)
 	pluginPath := flag.String("plugin-directory", v1beta1.DevicePluginPath, "The directory in which to create plugin sockets.")
 	logLevel := flag.String("log-level", logLevelInfo, fmt.Sprintf("Log level to use. Possible values: %s", availableLogLevels))


### PR DESCRIPTION
In some instances, the cardinality of globbed paths will be different.
The new `limit` field allows each match of a glob to be reused up to
<limit> times when other devices in a group yield more matches.  For
example, if one path in the group matches 5 devices and another matches
1 device but has a limit of 10, then the group will provide 5 pairs of
devices. When unspecified, Limit defaults to 1.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
