### PR TITLE
CI: don't push images on schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       run: make container
 
   push:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.event_name != 'schedule'
     needs:
     - build
     - linux


### PR DESCRIPTION
Currently, CI runs nightly and pushes images overwriting the tag for
`latest` and the most recent Git SHA. Overwriting latest would be OK but
overwriting the tag for the most recent SHA is problematic: just tagged
images that are not a floating reference should be static and
unchanging. This commit changes the CI configuration so that it does not
push images on nightly runs.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
