### PR TITLE
Fix busnum and devnum being converted to decimal

### DIFF
--- a/deviceplugin/usb.go
+++ b/deviceplugin/usb.go
@@ -34,7 +34,7 @@ const (
 	usbDevicesDirProductIDFile = "idProduct"
 	usbDevicesDirBusFile       = "busnum"
 	usbDevicesDirBusDevFile    = "devnum"
-	usbDevBus                  = "/dev/bus/usb/%03d/%03d"
+	usbDevBus                  = "/dev/bus/usb/%03x/%03x"
 )
 
 // USBSpec represents a USB device specification that should be discovered.


### PR DESCRIPTION
`busnum` and `devnum` are parsed as hex, but formatted as decimal. This is usually ok, but if a bus or dev number is above `9`, it will be incorrectly converted. I don't know enough about the Linux dev fs to know if these should be parsed as hex, but I'm sure that the same format should be used in both places.

For example, I have a printer on bus 3, device 14. I added some logging and can confirm the `/sys/bus/usb/devices` filesystem is read correctly:
```go
deviceplugin.usbDevice{Vendor:0x4a9, Product:0x172f, Bus:0x3, BusDevice:0x14}
```
While the values are parsed correctly, the path gets generated incorrectly as `/dev/bus/usb/003/020`.

```json
{"caller":"usb.go:256","level":"debug","msg":"USB device match","path":"/dev/bus/usb/003/020","resource":"squat.ai/canon-mp620","ts":"2023-07-09T22:06:29.687442411Z","usbdevice":"04a9:172f"}
```

This results in startup errors for pods that use these devices:
```
Error: failed to generate container "[...]" spec: failed to generate spec: lstat /dev/bus/usb/003/020: no such file or directory
```

This PR changes path generation to use hex format. After this change, the path is correctly generated as `/dev/bus/usb/003/014`.

Log after this PR:
```json
{"caller":"usb.go:256","level":"debug","msg":"USB device match","path":"/dev/bus/usb/003/014","resource":"squat.ai/canon-mp620","ts":"2023-07-09T22:07:23.393215872Z","usbdevice":"04a9:172f"}
```