### PR TITLE
deviceplugin/path: fix panic

### DIFF
--- a/deviceplugin/path.go
+++ b/deviceplugin/path.go
@@ -81,7 +81,7 @@ func (gp *GenericPlugin) discoverPath() ([]device, error) {
 				paths[i] = append(paths[i], matches...)
 			}
 			// Keep track of the shortest reusable length in the group.
-			if limitLength == 0 || len(paths[i]) < limitLength {
+			if i == 0 || len(paths[i]) < limitLength {
 				limitLength = len(paths[i])
 			}
 			// Keep track of the greatest natural length in the group.


### PR DESCRIPTION
This commit fixes a panic that occurs when the first device of a group
yields no matches but the second does.

Fixes: #36

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
