### PR TITLE
deviceplugin: add unit tests for discovery

### DIFF
--- a/absolute/fs.go
+++ b/absolute/fs.go
@@ -1,0 +1,92 @@
+// Copyright 2023 the generic-device-plugin authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package absolute
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+var _ fs.FS = (*FS)(nil)
+var _ fs.GlobFS = (*FS)(nil)
+var _ fs.ReadFileFS = (*FS)(nil)
+var _ fs.StatFS = (*FS)(nil)
+var _ fs.ReadDirFS = (*FS)(nil)
+var _ fs.SubFS = (*FS)(nil)
+
+type FS struct {
+	fs.FS
+	prefix string
+}
+
+func New(fsys fs.FS, prefix string) fs.FS {
+	return &FS{fsys, prefix}
+}
+
+func (f *FS) Open(name string) (fs.File, error) {
+	name, err := filepath.Rel(f.prefix, name)
+	if err != nil {
+		return nil, err
+	}
+	return f.FS.Open(strings.TrimPrefix(name, f.prefix))
+}
+
+func (f *FS) Glob(pattern string) ([]string, error) {
+	name, err := filepath.Rel(f.prefix, pattern)
+	if err != nil {
+		return nil, err
+	}
+	matches, err := fs.Glob(f.FS, name)
+	if err != nil {
+		return nil, err
+	}
+	for i := range matches {
+		matches[i] = filepath.Join(f.prefix, matches[i])
+	}
+	return matches, nil
+}
+
+func (f *FS) ReadFile(name string) ([]byte, error) {
+	name, err := filepath.Rel(f.prefix, name)
+	if err != nil {
+		return nil, err
+	}
+	return fs.ReadFile(f.FS, name)
+}
+
+func (f *FS) Stat(name string) (fs.FileInfo, error) {
+	name, err := filepath.Rel(f.prefix, name)
+	if err != nil {
+		return nil, err
+	}
+	return fs.Stat(f.FS, name)
+}
+
+func (f *FS) ReadDir(name string) ([]fs.DirEntry, error) {
+	name, err := filepath.Rel(f.prefix, name)
+	if err != nil {
+		return nil, err
+	}
+	return fs.ReadDir(f.FS, name)
+}
+
+func (f *FS) Sub(name string) (fs.FS, error) {
+	name, err := filepath.Rel(f.prefix, name)
+	if err != nil {
+		return nil, err
+	}
+	return fs.Sub(f.FS, name)
+}

--- a/deviceplugin/path.go
+++ b/deviceplugin/path.go
@@ -17,7 +17,7 @@ package deviceplugin
 import (
 	"crypto/sha1"
 	"fmt"
-	"path/filepath"
+	"io/fs"
 	"sort"
 	"strconv"
 
@@ -72,7 +72,7 @@ func (gp *GenericPlugin) discoverPath() ([]device, error) {
 		var limitLength int
 		// Discover all the devices matching each pattern in the Paths group.
 		for i, path := range group.Paths {
-			matches, err := filepath.Glob(path.Path)
+			matches, err := fs.Glob(gp.fs, path.Path)
 			if err != nil {
 				return nil, err
 			}

--- a/deviceplugin/path_test.go
+++ b/deviceplugin/path_test.go
@@ -1,0 +1,186 @@
+// Copyright 2023 the generic-device-plugin authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deviceplugin
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/squat/generic-device-plugin/absolute"
+	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+func TestDiscoverPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ds   *DeviceSpec
+		fs   fs.FS
+		out  []device
+		err  error
+	}{
+		{
+			name: "nil",
+			ds:   new(DeviceSpec),
+		},
+		{
+			name: "simple",
+			ds: &DeviceSpec{
+				Name: "simple",
+				Groups: []*Group{
+					{
+						Paths: []*Path{
+							{
+								Path: "/dev/simple",
+							},
+						},
+					},
+				},
+			},
+			fs: fstest.MapFS{
+				"dev/simple": {},
+			},
+			out: []device{
+				{
+					deviceSpecs: []*v1beta1.DeviceSpec{
+						{
+							ContainerPath: "/dev/simple",
+							HostPath:      "/dev/simple",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "multiple",
+			ds: &DeviceSpec{
+				Name: "serial",
+				Groups: []*Group{
+					{
+						Paths: []*Path{
+							{
+								Path:      "/dev/ttyUSB*",
+								MountPath: "/dev/ttyUSB0",
+							},
+						},
+					},
+				},
+			},
+			fs: fstest.MapFS{
+				"dev/ttyUSB0": {},
+				"dev/ttyUSB1": {},
+				"dev/ttyUSB2": {},
+				"dev/ttyUSB3": {},
+			},
+			out: []device{
+				{
+					deviceSpecs: []*v1beta1.DeviceSpec{
+						{
+							ContainerPath: "/dev/ttyUSB0",
+							HostPath:      "/dev/ttyUSB0",
+						},
+					},
+				},
+				{
+					deviceSpecs: []*v1beta1.DeviceSpec{
+						{
+							ContainerPath: "/dev/ttyUSB0",
+							HostPath:      "/dev/ttyUSB1",
+						},
+					},
+				},
+				{
+					deviceSpecs: []*v1beta1.DeviceSpec{
+						{
+							ContainerPath: "/dev/ttyUSB0",
+							HostPath:      "/dev/ttyUSB2",
+						},
+					},
+				},
+				{
+					deviceSpecs: []*v1beta1.DeviceSpec{
+						{
+							ContainerPath: "/dev/ttyUSB0",
+							HostPath:      "/dev/ttyUSB3",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "only one exists",
+			ds: &DeviceSpec{
+				Name: "only-one-exists",
+				Groups: []*Group{
+					{
+						Paths: []*Path{
+							{
+								Path: "/dev/does/not/exist",
+							},
+							{
+								Path: "/dev/does/exist",
+							},
+						},
+					},
+				},
+			},
+			fs: fstest.MapFS{
+				"dev/does/exist": {},
+			},
+			err: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ds.Default()
+			p := GenericPlugin{
+				ds: tc.ds,
+				fs: absolute.New(tc.fs, "/"),
+			}
+
+			out, err := p.discoverPath()
+			if (err != nil) != (tc.err != nil) {
+				t.Errorf("expected error %v; got %v", tc.err, err)
+			}
+			if len(out) != len(tc.out) {
+				t.Errorf("expected %d devices; got %d", len(tc.out), len(out))
+				return
+			}
+			for i := range out {
+				if len(out[i].deviceSpecs) != len(tc.out[i].deviceSpecs) {
+					t.Errorf("device %d: expected %d deviceSpecs; got %d", i, len(tc.out[i].deviceSpecs), len(out[i].deviceSpecs))
+					break
+				}
+				for j := range out[i].deviceSpecs {
+					if out[i].deviceSpecs[j].ContainerPath != tc.out[i].deviceSpecs[j].ContainerPath {
+						t.Errorf("device %d, device spec %d: expected container path %q; got %q", i, j, tc.out[i].deviceSpecs[j].ContainerPath, out[i].deviceSpecs[j].ContainerPath)
+					}
+					if out[i].deviceSpecs[j].HostPath != tc.out[i].deviceSpecs[j].HostPath {
+						t.Errorf("device %d, device spec %d: expected host path %q; got %q", i, j, tc.out[i].deviceSpecs[j].HostPath, out[i].deviceSpecs[j].HostPath)
+					}
+				}
+				for j := range out[i].mounts {
+					if out[i].mounts[j].ContainerPath != tc.out[i].mounts[j].ContainerPath {
+						t.Errorf("device %d, mount %d: expected container path %q; got %q", i, j, tc.out[i].mounts[j].ContainerPath, out[i].mounts[j].ContainerPath)
+					}
+					if out[i].mounts[j].HostPath != tc.out[i].mounts[j].HostPath {
+						t.Errorf("device %d, mount %d: expected host path %q; got %q", i, j, tc.out[i].mounts[j].HostPath, out[i].mounts[j].HostPath)
+					}
+				}
+			}
+		})
+	}
+}

--- a/deviceplugin/usb_test.go
+++ b/deviceplugin/usb_test.go
@@ -1,0 +1,113 @@
+// Copyright 2023 the generic-device-plugin authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deviceplugin
+
+import (
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/go-kit/kit/log"
+	"github.com/squat/generic-device-plugin/absolute"
+	"k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+)
+
+func TestDiscoverUSB(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ds   *DeviceSpec
+		fs   fs.FS
+		out  []device
+		err  error
+	}{
+		{
+			name: "nil",
+			ds:   new(DeviceSpec),
+		},
+		{
+			name: "simple",
+			ds: &DeviceSpec{
+				Name: "simple",
+				Groups: []*Group{
+					{
+						USBSpecs: []*USBSpec{
+							{
+								Vendor:  4176,
+								Product: 1031,
+							},
+						},
+					},
+				},
+			},
+			fs: fstest.MapFS{
+				"sys/bus/usb/devices/3-4/idVendor":  {Data: []byte("1050\n")},
+				"sys/bus/usb/devices/3-4/idProduct": {Data: []byte("0407\n")},
+				"sys/bus/usb/devices/3-4/busnum":    {Data: []byte("3\n")},
+				"sys/bus/usb/devices/3-4/devnum":    {Data: []byte("22\n")},
+			},
+			out: []device{
+				{
+					deviceSpecs: []*v1beta1.DeviceSpec{
+						{
+							ContainerPath: "/dev/bus/usb/003/022",
+							HostPath:      "/dev/bus/usb/003/022",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.ds.Default()
+			p := GenericPlugin{
+				ds:     tc.ds,
+				fs:     absolute.New(tc.fs, "/"),
+				logger: log.NewNopLogger(),
+			}
+
+			out, err := p.discoverUSB()
+			if (err != nil) != (tc.err != nil) {
+				t.Errorf("expected error %v; got %v", tc.err, err)
+			}
+			if len(out) != len(tc.out) {
+				t.Errorf("expected %d devices; got %d", len(tc.out), len(out))
+				return
+			}
+			for i := range out {
+				if len(out[i].deviceSpecs) != len(tc.out[i].deviceSpecs) {
+					t.Errorf("device %d: expected %d deviceSpecs; got %d", i, len(tc.out[i].deviceSpecs), len(out[i].deviceSpecs))
+					break
+				}
+				for j := range out[i].deviceSpecs {
+					if out[i].deviceSpecs[j].ContainerPath != tc.out[i].deviceSpecs[j].ContainerPath {
+						t.Errorf("device %d, device spec %d: expected container path %q; got %q", i, j, tc.out[i].deviceSpecs[j].ContainerPath, out[i].deviceSpecs[j].ContainerPath)
+					}
+					if out[i].deviceSpecs[j].HostPath != tc.out[i].deviceSpecs[j].HostPath {
+						t.Errorf("device %d, device spec %d: expected host path %q; got %q", i, j, tc.out[i].deviceSpecs[j].HostPath, out[i].deviceSpecs[j].HostPath)
+					}
+				}
+				for j := range out[i].mounts {
+					if out[i].mounts[j].ContainerPath != tc.out[i].mounts[j].ContainerPath {
+						t.Errorf("device %d, mount %d: expected container path %q; got %q", i, j, tc.out[i].mounts[j].ContainerPath, out[i].mounts[j].ContainerPath)
+					}
+					if out[i].mounts[j].HostPath != tc.out[i].mounts[j].HostPath {
+						t.Errorf("device %d, mount %d: expected host path %q; got %q", i, j, tc.out[i].mounts[j].HostPath, out[i].mounts[j].HostPath)
+					}
+				}
+			}
+		})
+	}
+}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -34,7 +34,7 @@ func kubectl(ctx context.Context, e e2e.Environment, extraArgs ...string) *exec.
 	return exec.CommandContext(ctx, "kubectl", append(args, extraArgs...)...)
 }
 
-func TestWebhook(t *testing.T) {
+func TestBasic(t *testing.T) {
 	t.Parallel()
 	e, err := e2e.NewKindEnvironment()
 	testutil.Ok(t, err)


### PR DESCRIPTION
This commit introduces a fairly significant refactor of the plugin code
so that it no longer implicitly depends on the host filesystem but
rather on an abstract fs.FS. This enables writing tests that mock out
the filesystem to test the discovery of devices. This commit also adds
some unit tests for both USB and path-based discovery.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
