### PR TITLE
deviceplugin: optimize usb device discovery

### DIFF
--- a/deviceplugin/usb.go
+++ b/deviceplugin/usb.go
@@ -234,9 +234,9 @@ func searchUSBDevices(devices *[]usbDevice, vendor USBID, product USBID) (devs [
 }
 
 func (gp *GenericPlugin) discoverUSB() (devices []device, err error) {
+	usbDevs, err := enumerateUSBDevices(gp.fs, usbDevicesDir)
 	for _, group := range gp.ds.Groups {
 		var paths []string
-		usbDevs, err := enumerateUSBDevices(gp.fs, usbDevicesDir)
 		if err != nil {
 			level.Warn(gp.logger).Log("msg", fmt.Sprintf("failed to enumerate usb devices: %v", err))
 			return devices, nil

--- a/deviceplugin/usb_test.go
+++ b/deviceplugin/usb_test.go
@@ -35,6 +35,7 @@ func TestDiscoverUSB(t *testing.T) {
 		{
 			name: "nil",
 			ds:   new(DeviceSpec),
+			fs:   fstest.MapFS{},
 		},
 		{
 			name: "simple",


### PR DESCRIPTION
Currently, all USB devices are enumerated for every single device group,
which is unnecessary: the devices only need to be enumerated once per
reconciliation.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
