### PR TITLE
Increase memory limits

### DIFF
--- a/manifests/generic-device-plugin.yaml
+++ b/manifests/generic-device-plugin.yaml
@@ -88,7 +88,7 @@ spec:
             memory: 10Mi
           limits:
             cpu: 50m
-            memory: 10Mi
+            memory: 20Mi
         ports:
         - containerPort: 8080
           name: http


### PR DESCRIPTION
After installing the daemonset in an empty cluster, I see 8Mi in memory utilization.
Once I start creating/deleting pods with resource definitions, it goes to 10Mi, and the pod restarts.
After increasing the memory, I don't see the behavior.

xref https://github.com/squat/generic-device-plugin/issues/37#issuecomment-1722321413