### PR TITLE
usb: allow specifying serial number

### DIFF
--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ Should be provided in the form:
 {"name": "<name>", "groups": [(device definitions)], "count": <count>}]}
 The device definition can be either a path to a device file or a USB device. You cannot define both in the same group.
 For device files, use something like: {"paths": [{"path": "<path-1>", "mountPath": "<mount-path-1>"},{"path": "<path-2>", "mountPath": "<mount-path-2>"}]}
-For USB devices, use something like: {"usb": [{"vendor": "1209", "product": "000F"}]}
+For USB devices, use something like: {"usb": [{"vendor": "1209", "product": "000F"}, {"vendor": "1209", "product": "000F", "serial": "00000001"}]}
 For example, to expose serial devices with different names: {"name": "serial", "groups": [{"paths": [{"path": "/dev/ttyUSB*"}]}, {"paths": [{"path": "/dev/ttyACM*"}]}]}
 The device flag can specify lists of devices that should be grouped and mounted into a container together as one single meta-device.
 For example, to allocate and mount an audio capture device: {"name": "capture", "groups": [{"paths": [{"path": "/dev/snd/pcmC0D0c"}, {"path": "/dev/snd/controlC0"}]}]}

--- a/deviceplugin/usb_test.go
+++ b/deviceplugin/usb_test.go
@@ -45,8 +45,8 @@ func TestDiscoverUSB(t *testing.T) {
 					{
 						USBSpecs: []*USBSpec{
 							{
-								Vendor:  4176,
-								Product: 1031,
+								Vendor:  0x1050,
+								Product: 0x0407,
 							},
 						},
 					},

--- a/deviceplugin/usb_test.go
+++ b/deviceplugin/usb_test.go
@@ -57,6 +57,7 @@ func TestDiscoverUSB(t *testing.T) {
 				"sys/bus/usb/devices/3-4/idProduct": {Data: []byte("0407\n")},
 				"sys/bus/usb/devices/3-4/busnum":    {Data: []byte("3\n")},
 				"sys/bus/usb/devices/3-4/devnum":    {Data: []byte("22\n")},
+				"sys/bus/usb/devices/3-4/serial":    {Data: []byte("51\n")},
 			},
 			out: []device{
 				{
@@ -64,6 +65,46 @@ func TestDiscoverUSB(t *testing.T) {
 						{
 							ContainerPath: "/dev/bus/usb/003/022",
 							HostPath:      "/dev/bus/usb/003/022",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "serial",
+			ds: &DeviceSpec{
+				Name: "serial",
+				Groups: []*Group{
+					{
+						USBSpecs: []*USBSpec{
+							{
+								Vendor:  0x1050,
+								Product: 0x0407,
+								Serial:  "52",
+							},
+						},
+					},
+				},
+			},
+			fs: fstest.MapFS{
+				"sys/bus/usb/devices/3-4/idVendor":  {Data: []byte("1050\n")},
+				"sys/bus/usb/devices/3-4/idProduct": {Data: []byte("0407\n")},
+				"sys/bus/usb/devices/3-4/busnum":    {Data: []byte("3\n")},
+				"sys/bus/usb/devices/3-4/devnum":    {Data: []byte("22\n")},
+				"sys/bus/usb/devices/3-4/serial":    {Data: []byte("51\n")},
+				"sys/bus/usb/devices/4-4/idVendor":  {Data: []byte("1050\n")},
+				"sys/bus/usb/devices/4-4/idProduct": {Data: []byte("0407\n")},
+				"sys/bus/usb/devices/4-4/busnum":    {Data: []byte("4\n")},
+				"sys/bus/usb/devices/4-4/devnum":    {Data: []byte("25\n")},
+				"sys/bus/usb/devices/4-4/serial":    {Data: []byte("52\n")},
+			},
+			out: []device{
+				{
+					deviceSpecs: []*v1beta1.DeviceSpec{
+						{
+							ContainerPath: "/dev/bus/usb/004/025",
+							HostPath:      "/dev/bus/usb/004/025",
 						},
 					},
 				},


### PR DESCRIPTION
This specifically solves a usecase I have where different RTL-SDRs (all of the same PID:VID) are attached to different antenna specific to certain frequencies (i.e. 433mhz for monitoring, 1090mhz for ADS-B, etc). Previously, I needed this plugin plus a node affinity rule.

This also contains a small patch to change the USB test to use base16 for the PID:VID so that it visually matches the mocked filesystem. I can make this a separate PR if you'd like.