### PR TITLE
Fix initial bool value to avoid sending update to kubelet every 5 seconds

### DIFF
--- a/deviceplugin/generic.go
+++ b/deviceplugin/generic.go
@@ -168,7 +168,7 @@ func (gp *GenericPlugin) refreshDevices() (bool, error) {
 	old := gp.devices
 	gp.devices = make(map[string]device)
 
-	var equal bool
+	equal := true
 	// Add the new devices to the map and check
 	// if they were in the old map.
 	for _, d := range devices {


### PR DESCRIPTION
`ListAndWatch()` uses return value of `refreshDevices()` to make a decision regarding sending the updated devices to kubelet.

Boolean default value is false, therefore variable `equal` is always false and `refreshDevices()` always returns false. This causes `ListAndWatch()` to always send updates to kubelets which causes flood of logs:

```
kubelet I0710 17:43:44.599983  286051 client.go:93] "State pushed for device plugin" resource="device.microshift.io/zigbee" resourceCapacity=1
kubelet I0710 17:43:44.605881  286051 manager.go:322] "Processed device updates for resource" resourceName="device.microshift.io/zigbee" totalCount=1 healthyCount=1
kubelet I0710 17:43:49.601009  286051 client.go:93] "State pushed for device plugin" resource="device.microshift.io/zigbee" resourceCapacity=1
kubelet I0710 17:43:49.605114  286051 manager.go:322] "Processed device updates for resource" resourceName="device.microshift.io/zigbee" totalCount=1 healthyCount=1
kubelet I0710 17:43:54.601267  286051 client.go:93] "State pushed for device plugin" resource="device.microshift.io/zigbee" resourceCapacity=1
kubelet I0710 17:43:54.613636  286051 manager.go:322] "Processed device updates for resource" resourceName="device.microshift.io/zigbee" totalCount=1 healthyCount=1
```