### PR TITLE
fix(CI): e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,13 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          tags: ghcr.io/${{ env.IMAGE_NAME }},docker.io/${{ env.IMAGE_NAME }}
+          tags: generic-device-plugin:test
           cache-from: type=gha
           cache-to: type=gha,mode=max
           load: "true"
       - uses: DeterminateSystems/nix-installer-action@v20
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - run: nix develop . --command go test -v ./...
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: e2e-capture
-          path: capture.png
 
   push:
     if: github.event_name != 'pull_request' && github.event_name != 'schedule'

--- a/deviceplugin/plugin.go
+++ b/deviceplugin/plugin.go
@@ -174,7 +174,8 @@ func (p *plugin) runOnce(ctx context.Context) error {
 		g.Add(func() error {
 			defer cancel()
 			_ = level.Info(p.logger).Log("msg", "waiting for the gRPC server to be ready")
-			c, err := grpc.NewClient(p.socket, grpc.WithTransportCredentials(insecure.NewCredentials()),
+			//nolint:all keep using deprecated gRPC functions for now
+			c, err := grpc.DialContext(ctx, p.socket, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock(),
 				grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 					return (&net.Dialer{}).DialContext(ctx, "unix", addr)
 				}),
@@ -224,7 +225,8 @@ func (p *plugin) runOnce(ctx context.Context) error {
 
 func (p *plugin) registerWithKubelet() error {
 	_ = level.Info(p.logger).Log("msg", "registering plugin with kubelet")
-	conn, err := grpc.NewClient(filepath.Join(p.pluginDir, filepath.Base(v1beta1.KubeletSocket)), grpc.WithTransportCredentials(insecure.NewCredentials()),
+	//nolint:all keep using deprecated gRPC functions for now
+	conn, err := grpc.Dial(filepath.Join(p.pluginDir, filepath.Base(v1beta1.KubeletSocket)), grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			d := &net.Dialer{}
 			return d.DialContext(ctx, "unix", addr)

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -39,7 +39,7 @@ func TestE2EBasic(t *testing.T) {
 	e, err := e2e.NewKindEnvironment()
 	testutil.Ok(t, err)
 	t.Cleanup(e.Close)
-	out, err := kind(context.Background(), e, "load", "docker-image", "docker.io/squat/generic-device-plugin").CombinedOutput()
+	out, err := kind(context.Background(), e, "load", "docker-image", "generic-device-plugin:test").CombinedOutput()
 	testutil.Ok(t, err, string(out))
 	a := e.Runnable("fuse").Init(e2e.StartOptions{
 		Image: "alpine",
@@ -50,6 +50,8 @@ func TestE2EBasic(t *testing.T) {
 	})
 	testutil.Ok(t, a.Start())
 	out, err = kubectl(context.Background(), e, "apply", "--filename", "manifests/generic-device-plugin.yaml").CombinedOutput()
+	testutil.Ok(t, err, string(out))
+	out, err = kubectl(context.Background(), e, "patch", "daemonset", "generic-device-plugin", "--namespace", "kube-system", "--patch", `{"spec": {"template": {"spec": {"containers": [{"name": "generic-device-plugin", "image": "generic-device-plugin:test", "imagePullPolicy": "Never"}]}}}}`).CombinedOutput()
 	testutil.Ok(t, err, string(out))
 	out, err = kubectl(context.Background(), e, "rollout", "status", "daemonset", "generic-device-plugin", "--namespace", "kube-system").CombinedOutput()
 	testutil.Ok(t, err, string(out))


### PR DESCRIPTION
The recent changes to the build-system broke CI. The biggest issue is
that CI has been improperly configured all along, allowing commits that
break the plugin to merge because the e2e tests use `imagePullPolicy:
Always`, meaning that the image that is used in CI is not the artifact
built from the commit but the image in the container registry. This
allowed a commit to merge a change that broke the gRPC code.

This commit reverts the breaking change to the gRPC code and fixes CI so
that the e2e tests are forced to use an image build from the proposed
commit, namely `generic-device-plugin:test` and not one that lives in
the container registry.

Signed-off-by: squat <lserven@gmail.com>
