### PR TITLE
feat: re-introduce ARM builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Extract Docker metadata
@@ -47,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/arm
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -57,8 +55,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build
@@ -84,8 +80,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
@@ -112,7 +106,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' && github.event_name != 'schedule' }}
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/arm
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,27 @@
               };
             };
 
+            generic-device-plugin-cross-linux-amd64 = generic-device-plugin.overrideAttrs {
+              env.GOOS = "linux";
+              env.GOARCH = "amd64";
+              env.CGO_ENABLED = 0;
+              checkPhase = false;
+            };
+
+            generic-device-plugin-cross-linux-arm = generic-device-plugin.overrideAttrs {
+              env.GOOS = "linux";
+              env.GOARCH = "arm";
+              env.CGO_ENABLED = 0;
+              checkPhase = false;
+            };
+
+            generic-device-plugin-cross-linux-arm64 = generic-device-plugin.overrideAttrs {
+              env.GOOS = "linux";
+              env.GOARCH = "arm64";
+              env.CGO_ENABLED = 0;
+              checkPhase = false;
+            };
+
             default = generic-device-plugin;
           };
 


### PR DESCRIPTION
When switching build-systems, build for ARMv7 were removed since the
official Nix Docker container doesn't offer ARM images. This commit
re-introduces ARM builds by using native cross-compilation with the
Golang toolchain rather than relying on compiling the Nix derivation on
the native platform. This has the added benefit of greatly accelerating
builds on non-native architectures, since cross-compiling with the
Golang toolchain is much faster than emulating a native compilation.

Signed-off-by: squat <lserven@gmail.com>
