### PR TITLE
feat(CI): update actions and sign commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@v20
+      - uses: DeterminateSystems/determinate-nix-action@v3.11.2
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - run: nix build
 
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/nix-installer-action@v20
+      - uses: DeterminateSystems/determinate-nix-action@v3.11.2
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - run: nix flake check -L --show-trace
 
@@ -66,7 +66,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           load: "true"
-      - uses: DeterminateSystems/nix-installer-action@v20
+      - uses: DeterminateSystems/determinate-nix-action@v3.11.2
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - run: nix develop . --command go test -v ./...
 

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -15,10 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: DeterminateSystems/determinate-nix-action@v3
-      - uses: DeterminateSystems/update-flake-lock@main
+      - uses: DeterminateSystems/determinate-nix-action@v3.11.2
+      - uses: DeterminateSystems/update-flake-lock@v27
         with:
-          pr-title: "Update Nix flake inputs" # Title of PR to be created
-          pr-labels: | # Labels to be set on the PR
+          pr-title: Update Nix flake inputs
+          pr-labels: |
             dependencies
             automated
+          sign-commits: true
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          git-author-name: pinguibot
+          git-author-email: bot@pingui.org
+          git-committer-name: pinguibot
+          git-committer-email: bot@pingui.org


### PR DESCRIPTION
This commit updates the GitHub Actions used in CI and configures signed
commits for flake lock update PRs.

Signed-off-by: squat <lserven@gmail.com>
