### PR TITLE
Allow to have optional devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Usage of generic-device-plugin:
                                   A "count" can be specified to allow a discovered device group to be scheduled multiple times.
                                   For example, to permit allocation of the FUSE device 10 times: {"name": "fuse", "groups": [{"count": 10, "paths": [{"path": "/dev/fuse"}]}]}
                                   Note: if omitted, "count" is assumed to be 1
+                                  An "optional" field can be specified for individual paths to allow containers to start even when some devices are missing.
+                                  For example, to expose serial devices that may or may not be present: {"name": "serial", "groups": [{"paths": [{"path": "/dev/ttyS0", "optional": true}, {"path": "/dev/ttyUSB0", "optional": true}]}]}
                                   If mountPath is a directory, the device will be mounted to the directory with the name of the device.
                                   For example, to expose the serial devices to the /dev/serial directory: {"name": "serial", "groups": [{"paths": [{"path": "/dev/ttyUSB*", "mountPath": "/dev/serial/"}]}]}
       --domain string             The domain to use when when declaring devices. (default "squat.ai")

--- a/config.go
+++ b/config.go
@@ -47,6 +47,8 @@ For example, to expose a CH340 serial converter: {"name": "ch340", "groups": [{"
 A "count" can be specified to allow a discovered device group to be scheduled multiple times.
 For example, to permit allocation of the FUSE device 10 times: {"name": "fuse", "groups": [{"count": 10, "paths": [{"path": "/dev/fuse"}]}]}
 Note: if omitted, "count" is assumed to be 1
+An "optional" field can be specified for individual paths to allow containers to start even when some devices are missing.
+For example, to expose serial devices that may or may not be present: {"name": "serial", "groups": [{"paths": [{"path": "/dev/ttyS0", "optional": true}, {"path": "/dev/ttyUSB0", "optional": true}]}]}
 If mountPath is a directory, the device will be mounted to the directory with the name of the device.
 For example, to expose the serial devices to the /dev/serial directory: {"name": "serial", "groups": [{"paths": [{"path": "/dev/ttyUSB*", "mountPath": "/dev/serial/"}]}]}`)
 	flag.String("plugin-directory", v1beta1.DevicePluginPath, "The directory in which to create plugin sockets.")

--- a/deviceplugin/path_test.go
+++ b/deviceplugin/path_test.go
@@ -200,6 +200,115 @@ func TestDiscoverPaths(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name: "optional paths - some missing",
+			ds: &DeviceSpec{
+				Name: "serial",
+				Groups: []*Group{
+					{
+						Paths: []*Path{
+							{
+								Path:     "/dev/ttyS0",
+								Optional: true,
+							},
+							{
+								Path:     "/dev/ttyUSB0",
+								Optional: true,
+							},
+							{
+								Path:     "/dev/ttyUSB1",
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			fs: fstest.MapFS{
+				"dev/ttyUSB0": {},
+			},
+			out: []device{
+				{
+					deviceSpecs: []*v1beta1.DeviceSpec{
+						{
+							ContainerPath: "/dev/ttyUSB0",
+							HostPath:      "/dev/ttyUSB0",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "optional paths - all present",
+			ds: &DeviceSpec{
+				Name: "serial",
+				Groups: []*Group{
+					{
+						Paths: []*Path{
+							{
+								Path:     "/dev/ttyS0",
+								Optional: true,
+							},
+							{
+								Path:     "/dev/ttyUSB0",
+								Optional: true,
+							},
+							{
+								Path:     "/dev/ttyUSB1",
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			fs: fstest.MapFS{
+				"dev/ttyS0":   {},
+				"dev/ttyUSB0": {},
+				"dev/ttyUSB1": {},
+			},
+			out: []device{
+				{
+					deviceSpecs: []*v1beta1.DeviceSpec{
+						{
+							ContainerPath: "/dev/ttyS0",
+							HostPath:      "/dev/ttyS0",
+						},
+						{
+							ContainerPath: "/dev/ttyUSB0",
+							HostPath:      "/dev/ttyUSB0",
+						},
+						{
+							ContainerPath: "/dev/ttyUSB1",
+							HostPath:      "/dev/ttyUSB1",
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "optional paths - all missing",
+			ds: &DeviceSpec{
+				Name: "serial",
+				Groups: []*Group{
+					{
+						Paths: []*Path{
+							{
+								Path:     "/dev/ttyS0",
+								Optional: true,
+							},
+							{
+								Path:     "/dev/ttyUSB0",
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			fs:  fstest.MapFS{},
+			out: []device{},
+			err: nil,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.ds.Default()


### PR DESCRIPTION
I have a use-case which I couldn't solve with the current version of the generic-device-plugin, because I have a container that I need to deploy of a lot of different target hosts. The hosts have one or multiple serial devices connected, but not always with the same paths. Some are connected directly to the ttyS0, while others are connected via a USB-adapter ttyUSB0. And the existence of the path doesn't say anything about if there is actually a serial device connected to it, it just means that the serial interface is there. So the ttyS0 is always there, even if the serial device is connected via USB, and some hosts have multiple serial devices connected to it, while others have only one connected (some only ttyS0, some only ttyUSB0 or only ttyUSB1, while others maybe have both USB devices connected).

The software running inside the container already handles this correctly, as it just probes all possible interfaces and checks on which of them something is connected (in the past it had to do the same running natively on the host, where also just all possible interfaces existed). So I just need to mount all existing devices on the host also to the container, and the software inside the container then handles the rest.

With the current version I wasn't able to achieve this, because if I define all paths, it only worked on the hosts where at least all serial interfaces are available (but didn't work on the hosts where the USB-interfaces were missing), and if I define them with a wildcard path or with multiple groups, it just mounted one of the paths, which might be the correct one, but often wasn't (and especially didn't work on the hosts with multiple serial devices connected).

This patch now allows me to use a config like this:
```yaml
  - name: serial
    groups:
      - paths:
          - path: /dev/ttyS0
            optional: true
          - path: /dev/ttyUSB0
            optional: true
          - path: /dev/ttyUSB1
            optional: true
```

This then mounts all paths that are available, but ignores the ones that are missing (which doesn't block starting the container because some resources are missing). So it solves my use-case.

What it doesn't do is, handling dynamically adding or removing devices after the container was started. But in my case the hardware is static (so devices don't get plugged or unplugged during runtime). But since the generic-device-plugin already scans for which devices are available, all it would require is something outside of the generic-device-plugin that monitors devices changes on the host and then triggering a restart of the specific containers. So I think it's fine to not handle this inside the generic-device-plugin.