### PR TITLE
feat: change default domain to devic.es

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Now, Pods that require a video capture device, such as an object detection servi
 ```yaml
 resources:
   limits:
-    squat.ai/video: 1
+    devic.es/video: 1
 ```
 
 The `--device` flag can be provided multiple times to allow the plugin to discover and allocate different types of resources.
@@ -61,7 +61,7 @@ spec:
       name: http
     resources:
       limits:
-        squat.ai/video: 1
+        devic.es/video: 1
 EOF
 ```
 
@@ -98,7 +98,7 @@ Usage of generic-device-plugin:
                                   For example, to expose serial devices that may or may not be present: {"name": "serial", "groups": [{"paths": [{"path": "/dev/ttyS0", "optional": true}, {"path": "/dev/ttyUSB0", "optional": true}]}]}
                                   If mountPath is a directory, the device will be mounted to the directory with the name of the device.
                                   For example, to expose the serial devices to the /dev/serial directory: {"name": "serial", "groups": [{"paths": [{"path": "/dev/ttyUSB*", "mountPath": "/dev/serial/"}]}]}
-      --domain string             The domain to use when when declaring devices. (default "squat.ai")
+      --domain string             The domain to use when when declaring devices. (default "devic.es")
       --listen string             The address at which to listen for health and metrics. (default ":8080")
       --log-level string          Log level to use. Possible values: all, debug, info, warn, error, none (default "info")
       --plugin-directory string   The directory in which to create plugin sockets. (default "/var/lib/kubelet/device-plugins/")

--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ import (
 	"github.com/squat/generic-device-plugin/deviceplugin"
 )
 
-const defaultDomain = "squat.ai"
+const defaultDomain = "devic.es"
 
 // initConfig defines config flags, config file, and envs
 func initConfig() error {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -55,7 +55,7 @@ func TestE2EBasic(t *testing.T) {
 	testutil.Ok(t, err, string(out))
 	out, err = kubectl(context.Background(), e, "rollout", "status", "daemonset", "generic-device-plugin", "--namespace", "kube-system").CombinedOutput()
 	testutil.Ok(t, err, string(out))
-	out, err = kubectl(context.Background(), e, "patch", "deployment", "fuse", "--patch", `{"spec": {"template": {"spec": {"containers": [{"name": "fuse", "resources": {"limits": {"squat.ai/fuse": 1}}}]}}}}`).CombinedOutput()
+	out, err = kubectl(context.Background(), e, "patch", "deployment", "fuse", "--patch", `{"spec": {"template": {"spec": {"containers": [{"name": "fuse", "resources": {"limits": {"devic.es/fuse": 1}}}]}}}}`).CombinedOutput()
 	testutil.Ok(t, err, string(out))
 	out, err = kubectl(context.Background(), e, "rollout", "status", "deployment", "fuse").CombinedOutput()
 	testutil.Ok(t, err, string(out))


### PR DESCRIPTION
This commit puts discovered devices under a more neutral domain
`devic.es`, which is a better default for most users. This is a breaking
change for the default manifests and so needed to be released after a
stable tag was released so users could pin to it easily.

Fixes #75
