### PR TITLE
feat(ci): push chart to ghcr and sign

### DIFF
--- a/.github/workflows/cd-helm-release.yml
+++ b/.github/workflows/cd-helm-release.yml
@@ -14,6 +14,8 @@ jobs:
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:
       contents: write
+      packages: write
+      id-token: write
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -33,7 +35,31 @@ jobs:
           version: v3.14.3
 
       - name: Run chart-releaser for generic-device-plugin
+        id: cr
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_GENERATE_RELEASE_NOTES: true
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Login to GHCR
+        if: steps.cr.outputs.changed_charts != ''
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to OCI registry
+        if: steps.cr.outputs.changed_charts != ''
+        run: helm push .cr-release-packages/*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+
+      - name: Install Cosign
+        if: steps.cr.outputs.changed_charts != ''
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Sign chart
+        if: steps.cr.outputs.changed_charts != ''
+        run: |
+          ref=ghcr.io/${{ github.repository_owner }}/charts/generic-device-plugin
+          digest=$(docker buildx imagetools inspect "${ref}:${{ steps.cr.outputs.chart_version }}" --format '{{.Manifest.Digest}}')
+          cosign sign --yes "${ref}@${digest}"

--- a/charts/generic-device-plugin/Chart.yaml
+++ b/charts/generic-device-plugin/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/generic-device-plugin/README.md
+++ b/charts/generic-device-plugin/README.md
@@ -1,6 +1,6 @@
 # generic-device-plugin
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the generic-device-plugin on Kubernetes
 


### PR DESCRIPTION
Adds steps to push the new chart to ghcr as an oci artifact and sign it with cosign keyless.

OCI charts are more efficient and portable than traditional http repos, in addition the chart "living" next to the image in ghcr is nice ux for users. Cosign signing allows verifying the chart has been pushed by the ci here and not by a bad actor.

Use:
` helm pull oci://ghcr.io/squat/charts/generic-device-plugin`
```
cosign verify ghcr.io/squat/charts/generic-device-plugin  \
      --certificate-identity-regexp 'https://github.com/squat/generic-device-plugin/' \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com
```
thanks!