### PR TITLE
feat(chart): add custom args, hostPathMounts, and devices config

### DIFF
--- a/charts/generic-device-plugin/Chart.yaml
+++ b/charts/generic-device-plugin/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/generic-device-plugin/README.md
+++ b/charts/generic-device-plugin/README.md
@@ -1,6 +1,6 @@
 # generic-device-plugin
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the generic-device-plugin on Kubernetes
 
@@ -14,8 +14,11 @@ A Helm chart for deploying the generic-device-plugin on Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| args | list | `[]` | additional CLI args appended to the generic-device-plugin container |
 | deployPodMonitor | bool | `true` | deploy the podMonitor (requires PodMonitor CRD to be installed) |
+| devices | list | `[]` | list of device specs that replace the built-in device args when non-empty. See https://github.com/squat/generic-device-plugin#overview for the schema. |
 | fullnameOverride | string | `""` | override the fullname of the chart resources |
+| hostPathMounts | list | `[]` | additional hostPath volumes to mount into the container. Each entry: {name, hostPath, mountPath, readOnly?, type?}. IMPORTANT: if any entry has a mountPath of /dev or under /dev/* the default /dev hostPath mount is dropped. |
 | image.pullPolicy | string | `"Always"` | image pullPolicy is set to always because tag is set to latest |
 | image.repository | string | `"squat/generic-device-plugin"` | container image repo |
 | image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/generic-device-plugin/README.md
+++ b/charts/generic-device-plugin/README.md
@@ -18,7 +18,7 @@ A Helm chart for deploying the generic-device-plugin on Kubernetes
 | deployPodMonitor | bool | `true` | deploy the podMonitor (requires PodMonitor CRD to be installed) |
 | devices | list | `[]` | list of device specs that replace the built-in device args when non-empty. See https://github.com/squat/generic-device-plugin#overview for the schema. |
 | fullnameOverride | string | `""` | override the fullname of the chart resources |
-| hostPathMounts | list | `[]` | additional hostPath volumes to mount into the container. Each entry: {name, hostPath, mountPath, readOnly?, type?}. IMPORTANT: if any entry has a mountPath of /dev or under /dev/* the default /dev hostPath mount is dropped. |
+| hostPathMounts | list | `[]` | additional hostPath volumes to mount into the container. Each entry: {name, hostPath, mountPath?, readOnly?, type?}. mountPath defaults to hostPath when unset. IMPORTANT: if any entry's effective mountPath is /dev or under /dev/* the default /dev hostPath mount is dropped. |
 | image.pullPolicy | string | `"Always"` | image pullPolicy is set to always because tag is set to latest |
 | image.repository | string | `"squat/generic-device-plugin"` | container image repo |
 | image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/generic-device-plugin/templates/daemonset.yaml
+++ b/charts/generic-device-plugin/templates/daemonset.yaml
@@ -1,3 +1,9 @@
+{{- $mountDev := true }}
+{{- range .Values.hostPathMounts }}
+  {{- if or (eq .mountPath "/dev") (hasPrefix "/dev/" .mountPath) }}
+    {{- $mountDev = false }}
+  {{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -34,6 +40,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+          {{- if .Values.devices }}
+          {{- range .Values.devices }}
+          - --device
+          - |
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- else }}
           - --device
           - |
             name: serial
@@ -92,6 +105,10 @@ spec:
                     mountPath: /dev/snd/controlC0
                   - path: /dev/snd/pcmC3D0c
                     mountPath: /dev/snd/pcmC0D0c
+          {{- end }}
+          {{- with .Values.args }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           ports:
@@ -102,14 +119,33 @@ spec:
           volumeMounts:
             - name: device-plugin
               mountPath: /var/lib/kubelet/device-plugins
+            {{- if $mountDev }}
             - name: dev
               mountPath: /dev
+            {{- end }}
+            {{- range .Values.hostPathMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              {{- with .readOnly }}
+              readOnly: {{ . }}
+              {{- end }}
+            {{- end }}
       volumes:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
+        {{- if $mountDev }}
         - name: dev
           hostPath:
             path: /dev
+        {{- end }}
+        {{- range .Values.hostPathMounts }}
+        - name: {{ .name }}
+          hostPath:
+            path: {{ .hostPath }}
+            {{- with .type }}
+            type: {{ . }}
+            {{- end }}
+        {{- end }}
   updateStrategy:
     type: RollingUpdate

--- a/charts/generic-device-plugin/templates/daemonset.yaml
+++ b/charts/generic-device-plugin/templates/daemonset.yaml
@@ -1,6 +1,7 @@
 {{- $mountDev := true }}
 {{- range .Values.hostPathMounts }}
-  {{- if or (eq .mountPath "/dev") (hasPrefix "/dev/" .mountPath) }}
+  {{- $mp := default .hostPath .mountPath }}
+  {{- if or (eq $mp "/dev") (hasPrefix "/dev/" $mp) }}
     {{- $mountDev = false }}
   {{- end }}
 {{- end }}
@@ -123,7 +124,7 @@ spec:
             {{- end }}
             {{- range .Values.hostPathMounts }}
             - name: {{ .name }}
-              mountPath: {{ .mountPath }}
+              mountPath: {{ default .hostPath .mountPath }}
               {{- with .readOnly }}
               readOnly: {{ . }}
               {{- end }}

--- a/charts/generic-device-plugin/values.yaml
+++ b/charts/generic-device-plugin/values.yaml
@@ -42,3 +42,13 @@ tolerations:
   effect: "NoSchedule"
 # -- deploy the podMonitor (requires PodMonitor CRD to be installed)
 deployPodMonitor: true
+# -- additional CLI args appended to the generic-device-plugin container
+args: []
+# -- additional hostPath volumes to mount into the container.
+# Each entry: {name, hostPath, mountPath, readOnly?, type?}.
+# IMPORTANT: if any entry has a mountPath of /dev or under /dev/*
+# the default /dev hostPath mount is dropped.
+hostPathMounts: []
+# -- list of device specs that replace the built-in device args when non-empty.
+# See https://github.com/squat/generic-device-plugin#overview for the schema.
+devices: []

--- a/charts/generic-device-plugin/values.yaml
+++ b/charts/generic-device-plugin/values.yaml
@@ -45,8 +45,9 @@ deployPodMonitor: true
 # -- additional CLI args appended to the generic-device-plugin container
 args: []
 # -- additional hostPath volumes to mount into the container.
-# Each entry: {name, hostPath, mountPath, readOnly?, type?}.
-# IMPORTANT: if any entry has a mountPath of /dev or under /dev/*
+# Each entry: {name, hostPath, mountPath?, readOnly?, type?}.
+# mountPath defaults to hostPath when unset.
+# IMPORTANT: if any entry's effective mountPath is /dev or under /dev/*
 # the default /dev hostPath mount is dropped.
 hostPathMounts: []
 # -- list of device specs that replace the built-in device args when non-empty.


### PR DESCRIPTION
adds configuration for `args`,`hostPath` mounts, and `devices` to the chart.

Mounts can be configured under `hostPathMounts` in the values. The current default of `/dev` remains unless a mount under `hostPathMounts` mounts `/dev` (if someone wants to set readOnly for example) or begins with /dev/. For example if someone adds `/dev/tun` the default `/dev` will be removed.

When `devices` is set the default devices args are replaced.

Chart version also updated to 0.2.0.

Let me know if this is acceptable, thanks!!