### PR TITLE
fix(chart): properly extract digest for cosign

### DIFF
--- a/.github/workflows/cd-helm-release.yml
+++ b/.github/workflows/cd-helm-release.yml
@@ -50,8 +50,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push chart to OCI registry
+        id: push
         if: steps.cr.outputs.changed_charts != ''
-        run: helm push .cr-release-packages/*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+        run: |
+          out=$(helm push .cr-release-packages/*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts)
+          echo "$out"
+          echo "digest=$(awk '/^Digest:/ {print $2}' <<<"$out")" >> "$GITHUB_OUTPUT"
 
       - name: Install Cosign
         if: steps.cr.outputs.changed_charts != ''
@@ -59,7 +63,4 @@ jobs:
 
       - name: Sign chart
         if: steps.cr.outputs.changed_charts != ''
-        run: |
-          ref=ghcr.io/${{ github.repository_owner }}/charts/generic-device-plugin
-          digest=$(docker buildx imagetools inspect "${ref}:${{ steps.cr.outputs.chart_version }}" --format '{{.Manifest.Digest}}')
-          cosign sign --yes "${ref}@${digest}"
+        run: cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/generic-device-plugin@${{ steps.push.outputs.digest }}"


### PR DESCRIPTION
Apparently the helm-releaser action sets chart_version as `chartName-chartVersion` which caused the workflow to fail, `helm push` outputs the digest so we can just take it from there.

I don't think there's any reason to bump the chart version here the signing is a nice-to-have and (hopefully 😄) it will work next version bump

https://github.com/squat/generic-device-plugin/actions/runs/25509132812/job/74862854014
