### PR TITLE
Remove duplicate `app.kubernetes.io/name` label from rendered manifests

### DIFF
--- a/charts/generic-device-plugin/Chart.yaml
+++ b/charts/generic-device-plugin/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/generic-device-plugin/README.md
+++ b/charts/generic-device-plugin/README.md
@@ -1,6 +1,6 @@
 # generic-device-plugin
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for deploying the generic-device-plugin on Kubernetes
 

--- a/charts/generic-device-plugin/templates/daemonset.yaml
+++ b/charts/generic-device-plugin/templates/daemonset.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ include "generic-device-plugin.fullname" . }}
   namespace: kube-system
   labels:
-    app.kubernetes.io/name: generic-device-plugin
     {{- include "generic-device-plugin.labels" . | nindent 4 }}
 spec:
   selector:
@@ -17,7 +16,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app.kubernetes.io/name: generic-device-plugin
         {{- include "generic-device-plugin.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/generic-device-plugin/templates/podmonitor.yaml
+++ b/charts/generic-device-plugin/templates/podmonitor.yaml
@@ -3,7 +3,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   labels:
-    app.kubernetes.io/name: generic-device-plugin
     {{- include "generic-device-plugin.labels" . | nindent 4 }}
   name: {{ include "generic-device-plugin.fullname" . }}
   namespace: kube-system


### PR DESCRIPTION
## Summary

The DaemonSet and PodMonitor templates emit `app.kubernetes.io/name: generic-device-plugin` twice on the same labels map — once literally, once via `{{- include "generic-device-plugin.labels" . | nindent N }}` (which transitively includes `selectorLabels`, which emits the same key). Helm tolerates duplicate map keys (last-wins), but strict YAML parsers — Kustomize, Flux v2's Kustomize-based `postRenderers`, ArgoCD with strict parsing, `kubeconform`, etc. — reject the rendered output.

## Reproduction (before this patch)

```
$ helm pull oci://ghcr.io/squat/charts/generic-device-plugin --version 0.1.1
$ helm template test ./generic-device-plugin-0.1.1.tgz > rendered.yaml
$ mkdir k && cp rendered.yaml k/ && printf 'resources:\n  - rendered.yaml\n' > k/kustomization.yaml
$ kustomize build k
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 10: mapping key "app.kubernetes.io/name" already defined at line 8
  line 23: mapping key "app.kubernetes.io/name" already defined at line 21
```

Rendered excerpt that triggers the failure:

```yaml
metadata:
  labels:
    app.kubernetes.io/name: generic-device-plugin     # ← literal in template
    helm.sh/chart: generic-device-plugin-0.1.1
    app.kubernetes.io/name: generic-device-plugin     # ← re-emitted by helper
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.2.0"
    app.kubernetes.io/managed-by: Helm
```

## Fix

Drop the three literal `app.kubernetes.io/name: generic-device-plugin` lines. The `generic-device-plugin.labels` helper already emits the same value via `selectorLabels`, so all rendered labels are identical to before — just deduplicated.

`matchLabels` blocks (DaemonSet `spec.selector.matchLabels`, PodMonitor `spec.selector.matchLabels`) intentionally keep the literal — those have to match what `selectorLabels` emits.

## Verification after this patch

```
$ helm template test ./inistor-generic-device-plugin/charts/generic-device-plugin > rendered.yaml
$ kustomize build k
# (clean output; PASS)
```

DaemonSet `metadata.labels` after patch:
```yaml
labels:
  app.kubernetes.io/instance: test
  app.kubernetes.io/managed-by: Helm
  app.kubernetes.io/name: generic-device-plugin     # only once now
  app.kubernetes.io/version: "0.2.0"
  helm.sh/chart: generic-device-plugin-0.1.1
```

## Context

Found this trying to install the chart via Flux v2 with a Kustomize `postRenderers` patch to extend the `--device` list with `/dev/kvm` (separately tracked in #209 / #206). The duplicate-label bug aborts the Helm install before any resource is applied, even with no postRenderer specified if any other tooling in the GitOps pipeline parses the rendered manifests strictly. We worked around it by shipping a raw DaemonSet manifest, but the chart is otherwise exactly what we want — so this small fix unblocks postRenderer-based usage.

---

Investigation and patch prepared with assistance from Claude ([Anthropic's CLI for software engineering](https://claude.com/claude-code)).