### PR TITLE
fix(ci): capture digest from helm stderr output

### DIFF
--- a/.github/workflows/cd-helm-release.yml
+++ b/.github/workflows/cd-helm-release.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@v3.5
-        with:
-          version: v3.14.3
 
       - name: Run chart-releaser for generic-device-plugin
         id: cr
@@ -53,7 +51,7 @@ jobs:
         id: push
         if: steps.cr.outputs.changed_charts != ''
         run: |
-          out=$(helm push .cr-release-packages/*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts)
+          out=$(helm push .cr-release-packages/*.tgz oci://ghcr.io/${{ github.repository_owner }}/charts 2>&1)
           echo "$out"
           echo "digest=$(awk '/^Digest:/ {print $2}' <<<"$out")" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
*third time's the charm*
fixes https://github.com/squat/generic-device-plugin/actions/runs/25805893711/job/75810381088

Helm weirdly outputs everything to stderr on push so the output was never captured into the variable. Looks like it will be swapped back to stdout with this https://github.com/helm/helm/pull/32056 but in the meantime pointing everything to stdout works and won't break if it changes again.

I also unpinned the helm version since it's 2 years old 😄 I didn't see a way to have it tracked with your dependabot config.

Thanks!